### PR TITLE
Preconfigure groups and addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The environment variables that can be provided are as follows:
 
 ---
 
-#### socketforwarder.tcp_port
+#### socketforwarder.tcp.port
 
 *If not provided the TCP forwarder will not run.*
 
@@ -40,7 +40,7 @@ This is the port that the TCP forwarder will listen on for new connections to jo
 
 ---
 
-#### socketforwarder.udp_port
+#### socketforwarder.udp.port
 
 *If not provided the UDP forwarder will not run.*
 
@@ -88,5 +88,15 @@ This will enable more logging of messages received, timing taken to forward and 
 *If not provided the value "0.0.0.0" is used.*
 
 This will be the address that the application binds to for both TCP and UDP.
+
+---
+
+#### socketforwarder.tcp.preconfig_addresses
+
+
+---
+
+#### socketforwarder.udp.preconfig_addresses
+
 
 ---

--- a/README.md
+++ b/README.md
@@ -93,10 +93,27 @@ This will be the address that the application binds to for both TCP and UDP.
 
 #### socketforwarder.tcp.preconfig_addresses
 
+*If not provided no addresses will be preconfigured into any TCP groups.*
+
+This property allows you to pre-register specific addresses under specific TCP groups during startup. This property acts as a whitelist for incoming TCP connections, any address in this list does not need to explicitly subscribe to the forwarder. Upon accepting the TCP connection request the forwarder will automatically place this socket into the correct group that was initially configured and forward appropriate messages to this connection.
+
+If there are any interruptions to the socket connection, the client can attempt to re-connect and the forwarder will maintain this preconfigured list for its lifetime and always automatically accept and emplace socket connections coming from the provided addresses into the correct group.
+
+The format for this property is as follows, firstly specifying the group ID, the address and port then commas after each entry. E.g. `"group1:localhost:12345,group1:localhost:34211,group2:localhost:45321"`
+
+For clarity, using the configuration above, any incoming TCP connection from "localhost:45321" will be accepted and placed immediately into the "group2" group. The client does not need to send any initial message to verify itself.
 
 ---
 
 #### socketforwarder.udp.preconfig_addresses
 
+*If not provided no addresses will be preconfigured into the UDP group.*
+
+This property allows you to pre-register specific addresses under the UDP group. Meaning that the UDP clients do not need to register or subscribe to the forwarder, the forwarder will automatically add these address (if resolved successfully) and begin forwarding messages to theses addresses immediately.
+
+Since the UDP forwarder cannot detect disconnections through UDP, any address added will continue to have all messages forwarded to it until the forwarder is stopped.
+
+The format for this is a comma separated list of "hostname:port".
+E.g. `"localhost:65432,localhost:44321"`
 
 ---

--- a/socket-forwarder/environment/Environment.h
+++ b/socket-forwarder/environment/Environment.h
@@ -7,14 +7,24 @@ namespace forwarder
 {
     const std::string SOCKET_FORWARDER_PREFIX = "socketforwarder.";
     const std::string HOST_ADDRESS = SOCKET_FORWARDER_PREFIX + "host_address";
-    const std::string TCP_PORT = SOCKET_FORWARDER_PREFIX + "tcp_port";
-    const std::string UDP_PORT = SOCKET_FORWARDER_PREFIX + "udp_port";
     const std::string NEW_CLIENT_PREFIX = SOCKET_FORWARDER_PREFIX + "new_client_prefix";
     const std::string MAX_READ_IN_SIZE = SOCKET_FORWARDER_PREFIX + "max_read_in_size";
     const std::string DEBUG = SOCKET_FORWARDER_PREFIX + "debug";
 
+    const std::string PRECONFIG_ADDRESS_SUFFIX = "preconfig_address";
+    const std::string PORT_SUFFIX = "port";
+
+    const std::string TCP = "tcp.";
+    const std::string TCP_PORT = SOCKET_FORWARDER_PREFIX + TCP + PORT_SUFFIX;
+    const std::string PRECONFIG_TCP_ADDRESSES = SOCKET_FORWARDER_PREFIX + TCP + PRECONFIG_ADDRESS_SUFFIX;
+    
+    const std::string UDP = "udp.";
+    const std::string UDP_PORT = SOCKET_FORWARDER_PREFIX + UDP + PORT_SUFFIX;
+    const std::string PRECONFIG_UDP_ADDRESSES = SOCKET_FORWARDER_PREFIX + UDP + PRECONFIG_ADDRESS_SUFFIX;
+
     const std::string NEW_CLIENT_PREFIX_DEFAULT = "SOCKETFORWARDER-NEW:";
     const unsigned short MAX_READ_IN_DEFAULT = 10240;
+    const std::string HOST_ADDRESS_DEFAULT = "0.0.0.0";
 
     std::optional<std::string> getEnvironmentVariableValue(std::string);
 

--- a/socket-forwarder/environment/Environment.h
+++ b/socket-forwarder/environment/Environment.h
@@ -11,16 +11,16 @@ namespace forwarder
     const std::string MAX_READ_IN_SIZE = SOCKET_FORWARDER_PREFIX + "max_read_in_size";
     const std::string DEBUG = SOCKET_FORWARDER_PREFIX + "debug";
 
-    const std::string PRECONFIG_ADDRESS_SUFFIX = "preconfig_address";
+    const std::string PRECONFIG_ADDRESSES_SUFFIX = "preconfig_addresses";
     const std::string PORT_SUFFIX = "port";
 
     const std::string TCP = "tcp.";
     const std::string TCP_PORT = SOCKET_FORWARDER_PREFIX + TCP + PORT_SUFFIX;
-    const std::string PRECONFIG_TCP_ADDRESSES = SOCKET_FORWARDER_PREFIX + TCP + PRECONFIG_ADDRESS_SUFFIX;
+    const std::string PRECONFIG_TCP_ADDRESSES = SOCKET_FORWARDER_PREFIX + TCP + PRECONFIG_ADDRESSES_SUFFIX;
     
     const std::string UDP = "udp.";
     const std::string UDP_PORT = SOCKET_FORWARDER_PREFIX + UDP + PORT_SUFFIX;
-    const std::string PRECONFIG_UDP_ADDRESSES = SOCKET_FORWARDER_PREFIX + UDP + PRECONFIG_ADDRESS_SUFFIX;
+    const std::string PRECONFIG_UDP_ADDRESSES = SOCKET_FORWARDER_PREFIX + UDP + PRECONFIG_ADDRESSES_SUFFIX;
 
     const std::string NEW_CLIENT_PREFIX_DEFAULT = "SOCKETFORWARDER-NEW:";
     const unsigned short MAX_READ_IN_DEFAULT = 10240;

--- a/socket-forwarder/forwarder/Forwarder.cpp
+++ b/socket-forwarder/forwarder/Forwarder.cpp
@@ -124,7 +124,7 @@ namespace forwarder
 
                     if (debug)
                     {   
-                        std::cout << "[TCP] - Accepted connection message: " << firstMessage << "\n";
+                        std::cout << "[TCP] - Accepted connection message: [" << firstMessage << "]\n";
                     }
 
                     if (firstMessage.rfind(newClientPrefix, 0) == 0)
@@ -191,7 +191,7 @@ namespace forwarder
                                 {
                                     if (debug)
                                     {
-                                        std::cout << "[TCP - " + uuidString + "] - Group [" << groupID << "], peer [" << j << "] is no longer connected, removing from group.\n";
+                                        std::cout << "[TCP - " + uuidString + "] - Group [" << groupID << "], peer [" << j << "] is no longer connected, marking for removal from group.\n";
                                     }
                                     toRemove.push_back(j);
                                 }
@@ -208,7 +208,7 @@ namespace forwarder
                                     {
                                         if (debug)
                                         {
-                                            std::cout << "[TCP - " + uuidString + "] - Group [" << groupID << "], failed to send to peer [" << j << "], removing from group.\n";
+                                            std::cout << "[TCP - " + uuidString + "] - Group [" << groupID << "], failed to send to peer [" << j << "], marking for removal from group.\n";
                                         }
                                         toRemove.push_back(j);
                                     }
@@ -224,6 +224,7 @@ namespace forwarder
                         for (size_t index : toRemove)
                         {
                             std::vector<kt::TCPSocket>::iterator socketPosition = std::next(it->second.begin(), index);
+                            std::cout << "[TCP - " + uuidString + "] - Group [" << groupID << "] - Closing and removing socket with address [" << kt::getAddress(socketPosition->getSocketAddress()).value_or("") + ":" + std::to_string(kt::getPortNumber(socketPosition->getSocketAddress())) << "].\n";
                             socketPosition->close();
                             it->second.erase(socketPosition);
                         }

--- a/socket-forwarder/forwarder/Forwarder.h
+++ b/socket-forwarder/forwarder/Forwarder.h
@@ -49,6 +49,8 @@ namespace forwarder
         std::optional<kt::UDPSocket> udpRecieveSocket = std::nullopt;
         std::optional<kt::ServerSocket> tcpServerSocket = std::nullopt;
 
+        std::unordered_map<kt::SocketAddress, std::string, AddressHash, AddressEqual> tcpPreconfigured;
+
         void startUDPForwarder();
         void startUDPListener();
         void startUDPDataForwarder();
@@ -62,7 +64,7 @@ namespace forwarder
     public:
         Forwarder(std::optional<kt::ServerSocket>, std::optional<kt::UDPSocket>, const std::string, const unsigned short, const bool);
 
-        void addAddressToTCPGroup(const std::string&, kt::SocketAddress);
+        void preConfigureTCPAddress(const std::string&, kt::SocketAddress);
         void addAddressToUDPGroup(kt::SocketAddress);
 
         bool tcpGroupWithIdExists(std::string&);

--- a/socket-forwarder/forwarder/Forwarder.h
+++ b/socket-forwarder/forwarder/Forwarder.h
@@ -57,8 +57,13 @@ namespace forwarder
         void startTCPConnectionListener();
         void startTCPDataForwarder();
 
+        void addSocketToTCPGroup(const std::string&, kt::TCPSocket);
+
     public:
         Forwarder(std::optional<kt::ServerSocket>, std::optional<kt::UDPSocket>, const std::string, const unsigned short, const bool);
+
+        void addAddressToTCPGroup(const std::string&, kt::SocketAddress);
+        void addAddressToUDPGroup(kt::SocketAddress);
 
         bool tcpGroupWithIdExists(std::string&);
         size_t tcpGroupMemberCount(std::string&);

--- a/socket-forwarder/main.cpp
+++ b/socket-forwarder/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
         {
             for (const kt::SocketAddress& addr : it.second)
             {
-                forwarder.addAddressToTCPGroup(it.first, addr);
+                forwarder.preConfigureTCPAddress(it.first, addr);
             }
         }
     }

--- a/socket-forwarder/main.cpp
+++ b/socket-forwarder/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
     std::vector<kt::SocketAddress> udpPreconfiguredAddresses = forwarder::getPreconfiguredUDPAddresses();
     if (!udpPreconfiguredAddresses.empty())
     {
-        std::cout << "UDP preconfigured addresses provided, setting into forwarder...";
+        std::cout << "UDP preconfigured addresses provided, setting into forwarder..." << std::endl;
         for (const kt::SocketAddress& addr : udpPreconfiguredAddresses)
         {
             forwarder.addAddressToUDPGroup(addr);
@@ -43,7 +43,7 @@ int main(int argc, char** argv)
     std::unordered_map<std::string, std::vector<kt::SocketAddress>> tcpPreconfiguredAddresses = forwarder::getPreconfiguredTCPAddresses();
     if (!tcpPreconfiguredAddresses.empty())
     {
-        std::cout << "TCP preconfigured addresses provided, setting into forwarder...";
+        std::cout << "TCP preconfigured addresses provided, setting into forwarder..." << std::endl;
         for (const auto& it : tcpPreconfiguredAddresses)
         {
             for (const kt::SocketAddress& addr : it.second)

--- a/socket-forwarder/sockets/Sockets.cpp
+++ b/socket-forwarder/sockets/Sockets.cpp
@@ -84,7 +84,11 @@ namespace forwarder
         for (const std::string& s : addressStrings)
         {
             std::vector<std::string> parts = split(s, ":");
-            if (parts.size() < 3)
+            if (parts.size() == 1 && parts[0] == "")
+            {
+                // Skip
+            }
+            else if (parts.size() < 3)
             {
                 std::cout << "[TCP] - Unable to add address [" << s << "], expected format to be \"<groupId>:<address>:<port number>\"." << std::endl;
             }
@@ -134,7 +138,11 @@ namespace forwarder
         for (const std::string& s : addressStrings)
         {
             std::vector<std::string> parts = split(s, ":");
-            if (parts.size() < 2)
+            if (parts.size() == 1 && parts[0] == "")
+            {
+                // Skip
+            }
+            else if (parts.size() < 2)
             {
                 std::cout << "[UDP] - Unable to add address [" << s << "], expected format to be \"<address>:<port number>\"." << std::endl;
             }

--- a/socket-forwarder/sockets/Sockets.cpp
+++ b/socket-forwarder/sockets/Sockets.cpp
@@ -23,7 +23,7 @@ namespace forwarder
 
         try
         {
-            kt::ServerSocket serverSocket(kt::SocketType::Wifi, getEnvironmentVariableValueOrDefault(HOST_ADDRESS, std::string("0.0.0.0")), portNumber);
+            kt::ServerSocket serverSocket(kt::SocketType::Wifi, getEnvironmentVariableValueOrDefault(HOST_ADDRESS, HOST_ADDRESS_DEFAULT), portNumber);
             return std::make_optional(serverSocket);
         }
         catch(const kt::BindingException e)
@@ -54,7 +54,7 @@ namespace forwarder
         try
         {
             kt::UDPSocket udpSocket;
-            if (!udpSocket.bind(getEnvironmentVariableValueOrDefault(HOST_ADDRESS, std::string("0.0.0.0")), portNumber).first)
+            if (!udpSocket.bind(getEnvironmentVariableValueOrDefault(HOST_ADDRESS, HOST_ADDRESS_DEFAULT), portNumber).first)
             {
                 std::cout << "[UDP] - Failed to bind to provided port " << portNumber << "\n";
                 return std::nullopt;
@@ -71,5 +71,119 @@ namespace forwarder
             std::cout << "[UDP] - Failed to create UDP socket: " << e.what() << std::endl;
             return std::nullopt;
         }
+    }
+
+    /**
+     * Expected format for TCP connections is "<groupID>:<address>:<port>,<groupID2>:<address2>:<port2>".
+     */
+    std::unordered_map<std::string, std::vector<kt::SocketAddress>> getPreconfiguredTCPAddresses(const std::string defaultValue)
+    {
+        std::unordered_map<std::string, std::vector<kt::SocketAddress>> addresses;
+        std::vector<std::string> addressStrings = split(getEnvironmentVariableValueOrDefault(PRECONFIG_TCP_ADDRESSES, defaultValue), ",");
+        
+        for (const std::string& s : addressStrings)
+        {
+            std::vector<std::string> parts = split(s, ":");
+            if (parts.size() < 3)
+            {
+                std::cout << "[TCP] - Unable to add address [" << s << "], expected format to be \"<groupId>:<address>:<port number>\"." << std::endl;
+            }
+            else
+            {
+                if (parts.size() > 3)
+                {
+                    std::cout << "[TCP] - Multiple ':' provided in address string [" << s << "]. Attempting to parse and add address to group [" << parts[0] << "] using second and third elements as the address [" << parts[1] << ", " << parts[2] << "]." << std::endl;
+                }
+
+                unsigned short portNumber = static_cast<unsigned short>(std::atoi(parts[2].c_str()));
+                addrinfo info = kt::createTcpHints();
+                std::pair<std::vector<kt::SocketAddress>, int> resolvedAddresses = kt::resolveToAddresses(parts[1], portNumber, info);
+                if (resolvedAddresses.first.empty())
+                {
+                    std::cout << "[TCP] - Failed to resolve address [" << parts[1] << ":" << portNumber << "]. Address will not be added to TCP group [" << parts[0] << "]." << std::endl;
+                }
+                else
+                {
+                    kt::SocketAddress addr = resolvedAddresses.first.at(0);
+                    std::cout << "[TCP] - Resolved and added pre-configured address [" << kt::getAddress(addr).value_or("") + ":" + std::to_string(kt::getPortNumber(addr)) << "] to group [" << parts[0] << "]." << std::endl;
+
+                    if (addresses.find(parts[0]) == addresses.end())
+                    {
+                        std::vector<kt::SocketAddress> addrVec = { addr };
+                        addresses.insert(std::make_pair(parts[0], addrVec));
+                    }
+                    else
+                    {
+                        addresses[parts[0]].push_back(addr);
+                    }
+                }
+            }
+        }
+
+        return addresses;
+    }
+
+    /**
+     * Expected format for UDP connections is "<address>:<port>,<address2>:<port2>".
+     */
+    std::vector<kt::SocketAddress> getPreconfiguredUDPAddresses(const std::string defaultValue)
+    {
+        std::vector<kt::SocketAddress> addresses;
+        std::vector<std::string> addressStrings = split(getEnvironmentVariableValueOrDefault(PRECONFIG_UDP_ADDRESSES, defaultValue), ",");
+
+        for (const std::string& s : addressStrings)
+        {
+            std::vector<std::string> parts = split(s, ":");
+            if (parts.size() < 2)
+            {
+                std::cout << "[UDP] - Unable to add address [" << s << "], expected format to be \"<address>:<port number>\"." << std::endl;
+            }
+            else
+            {
+                if (parts.size() > 2)
+                {
+                    std::cout << "[UDP] - Multiple ':' provided in address string [" << s << "]. Attempting to parse as address using first two elements [" << parts[0] << ", " << parts[1] << "]." << std::endl;
+                }
+
+                unsigned short portNumber = static_cast<unsigned short>(std::atoi(parts[1].c_str()));
+                addrinfo info = kt::createUdpHints();
+                std::pair<std::vector<kt::SocketAddress>, int> resolvedAddresses = kt::resolveToAddresses(parts[0], portNumber, info);
+                if (resolvedAddresses.first.empty())
+                {
+                    std::cout << "[UDP] - Failed to resolve address [" << parts[0] << ":" << portNumber << "]. Address will not be added to UDP group." << std::endl;
+                }
+                else
+                {
+                    kt::SocketAddress addr = resolvedAddresses.first.at(0);
+                    std::cout << "[UDP] - Resolved and added pre-configured address [" << kt::getAddress(addr).value_or("") + ":" + std::to_string(kt::getPortNumber(addr)) << "] to UDP group." << std::endl;
+                    addresses.push_back(addr);
+                }
+            }
+        }
+
+        return addresses;
+    }
+
+    std::vector<std::string> split(const std::string& input, const std::string& delimiter)
+    {
+        std::vector<std::string> tokens;
+        size_t index = 0;
+
+        while(index != -1)
+        {
+            size_t result = input.find(delimiter, index);
+            if (result != -1)
+            {
+                tokens.push_back(input.substr(index, result - index));
+                index = result + delimiter.size();
+            }
+            else
+            {
+                tokens.push_back(input.substr(index));
+                index = -1;
+            }
+        }
+
+        return tokens;
     }
 }

--- a/socket-forwarder/sockets/Sockets.cpp
+++ b/socket-forwarder/sockets/Sockets.cpp
@@ -28,7 +28,7 @@ namespace forwarder
         }
         catch(const kt::BindingException e)
         {
-            std::cout << "[TCP] - Failed to bind server socket on port: " << portNumber << ". " << e.what() << std::endl;
+            std::cout << "[TCP] - Failed to bind server socket on port [" << portNumber << "]. " << e.what() << std::endl;
             return std::nullopt;
         }
         catch (const kt::SocketException e)
@@ -56,14 +56,14 @@ namespace forwarder
             kt::UDPSocket udpSocket;
             if (!udpSocket.bind(getEnvironmentVariableValueOrDefault(HOST_ADDRESS, HOST_ADDRESS_DEFAULT), portNumber).first)
             {
-                std::cout << "[UDP] - Failed to bind to provided port " << portNumber << "\n";
+                std::cout << "[UDP] - Failed to bind to provided port [" << portNumber << "].\n";
                 return std::nullopt;
             }
             return std::make_optional(udpSocket);
         }
         catch(const kt::BindingException e)
         {
-            std::cout << "[UDP] - Failed to bind UDP socket on port: " << portNumber << ". " << e.what() << std::endl;
+            std::cout << "[UDP] - Failed to bind UDP socket on port: [" << portNumber << "]. " << e.what() << std::endl;
             return std::nullopt;
         }
         catch (const kt::SocketException e)

--- a/socket-forwarder/sockets/Sockets.cpp
+++ b/socket-forwarder/sockets/Sockets.cpp
@@ -84,7 +84,7 @@ namespace forwarder
         for (const std::string& s : addressStrings)
         {
             std::vector<std::string> parts = split(s, ":");
-            if (parts.size() == 1 && parts[0] == "")
+            if (parts.size() == 1 && parts[0].empty())
             {
                 // Skip
             }
@@ -138,7 +138,7 @@ namespace forwarder
         for (const std::string& s : addressStrings)
         {
             std::vector<std::string> parts = split(s, ":");
-            if (parts.size() == 1 && parts[0] == "")
+            if (parts.size() == 1 && parts[0].empty())
             {
                 // Skip
             }

--- a/socket-forwarder/sockets/Sockets.h
+++ b/socket-forwarder/sockets/Sockets.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <optional>
+#include <unordered_map>
+#include <vector>
 
 #include <serversocket/ServerSocket.h>
 #include <socket/UDPSocket.h>
@@ -10,4 +12,10 @@ namespace forwarder
     std::optional<kt::ServerSocket> setUpTcpServerSocket(std::optional<std::string> = std::nullopt);
 
     std::optional<kt::UDPSocket> setUpUDPSocket(std::optional<std::string> = std::nullopt);
+
+    std::unordered_map<std::string, std::vector<kt::SocketAddress>> getPreconfiguredTCPAddresses(const std::string = "");
+
+    std::vector<kt::SocketAddress> getPreconfiguredUDPAddresses(const std::string = "");
+
+    std::vector<std::string> split(const std::string&, const std::string&);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,8 +20,10 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 set(FORWARDER_TEST_SOURCE
-    socket-forwarder/TCPSocketForwarderTest.cpp
-    socket-forwarder/UDPSocketForwarderTest.cpp
+    socket-forwarder/forwarder/TCPSocketForwarderTest.cpp
+    socket-forwarder/forwarder/UDPSocketForwarderTest.cpp
+
+    socket-forwarder/sockets/SocketsTest.cpp
 )
 
 # This is duplicated from the parent CMakeLists.txt, since these are needed to build the tests

--- a/tests/socket-forwarder/forwarder/TCPSocketForwarderTest.cpp
+++ b/tests/socket-forwarder/forwarder/TCPSocketForwarderTest.cpp
@@ -4,8 +4,8 @@
 
 #include <csignal>
 
-#include "../../socket-forwarder/environment/Environment.h"
-#include "../../socket-forwarder/forwarder/Forwarder.h"
+#include "../../../socket-forwarder/environment/Environment.h"
+#include "../../../socket-forwarder/forwarder/Forwarder.h"
 
 using namespace std::chrono_literals;
 

--- a/tests/socket-forwarder/forwarder/UDPSocketForwarderTest.cpp
+++ b/tests/socket-forwarder/forwarder/UDPSocketForwarderTest.cpp
@@ -3,8 +3,8 @@
 #include <chrono>
 #include <future>
 
-#include "../../socket-forwarder/environment/Environment.h"
-#include "../../socket-forwarder/forwarder/Forwarder.h"
+#include "../../../socket-forwarder/environment/Environment.h"
+#include "../../../socket-forwarder/forwarder/Forwarder.h"
 
 using namespace std::chrono_literals;
 

--- a/tests/socket-forwarder/sockets/SocketsTest.cpp
+++ b/tests/socket-forwarder/sockets/SocketsTest.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include "../../../socket-forwarder/sockets/Sockets.h"
+
+namespace forwarder
+{
+    TEST(SocketsTest, SocketsSplit_withElements)
+    {
+        std::string input = "some-text-that-is-separated...";
+        std::string delimiter = "-";
+
+        std::vector<std::string> strings = split(input, delimiter);
+        std::vector<std::string> expected = {"some", "text", "that", "is", "separated..."};
+
+        ASSERT_EQ(expected.size(), strings.size());
+        for (int i = 0; i < expected.size(); i++)
+        {
+            ASSERT_EQ(expected[i], strings[i]);
+        }
+    }
+
+    TEST(SocketsTest, SocketsSplit_emptyInput)
+    {
+        std::string input = "";
+        std::string delimiter = "-";
+
+        std::vector<std::string> strings = split(input, delimiter);
+        std::vector<std::string> expected = { "" };
+
+        ASSERT_EQ(expected.size(), strings.size());
+        for (int i = 0; i < expected.size(); i++)
+        {
+            ASSERT_EQ(expected[i], strings[i]);
+        }
+    }
+
+    TEST(SocketsTest, SocketsSplit_delimiterDoesNotExist)
+    {
+        std::string input = "some-text-that-is-separated...";
+        std::string delimiter = "!";
+
+        std::vector<std::string> strings = split(input, delimiter);
+        std::vector<std::string> expected = { "some-text-that-is-separated..." };
+
+        ASSERT_EQ(expected.size(), strings.size());
+        for (int i = 0; i < expected.size(); i++)
+        {
+            ASSERT_EQ(expected[i], strings[i]);
+        }
+    }
+
+    TEST(SocketsTest, getPreconfiguredTCPAddresses)
+    {
+        std::string input = "group1:localhost:54321,group1:localhost:11223,group2:localhost:2255";
+        std::unordered_map<std::string, std::vector<kt::SocketAddress>> address = getPreconfiguredTCPAddresses(input);
+    
+        auto group1 = address.find("group1");
+        ASSERT_NE(address.end(), group1);
+        ASSERT_EQ(2, group1->second.size());
+        for (const kt::SocketAddress addr : group1->second)
+        {
+            unsigned short port = kt::getPortNumber(addr);
+            ASSERT_TRUE(port == 54321 || port == 11223);
+        }
+
+        auto group2 = address.find("group2");
+        ASSERT_EQ(1, group2->second.size());
+        ASSERT_NE(address.end(), group2);
+        for (const kt::SocketAddress addr : group2->second)
+        {
+            ASSERT_EQ(2255, kt::getPortNumber(addr));
+        }
+
+        ASSERT_EQ(address.end(), address.find("group3"));
+    }
+
+    TEST(SocketsTest, getPreconfiguredUDPAddresses)
+    {
+        std::string input = "localhost:33333,localhost:12345";
+        std::vector<kt::SocketAddress> addresses = getPreconfiguredUDPAddresses(input);
+
+        ASSERT_EQ(2, addresses.size());
+        for (const kt::SocketAddress addr : addresses)
+        {
+            unsigned short port = kt::getPortNumber(addr);
+            ASSERT_TRUE(port == 33333 || port == 12345);
+        }
+    }
+}


### PR DESCRIPTION
Add preconfiguration for UDP forwarder and TCP forwarder so that either addresses are automatically forwarded to (for UDP) or added to a "whitelist" where accepted connections from addresses in this list are automatically accepted and added to their preconfigured group.